### PR TITLE
Use location parameter from main deployment in nested deployments

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -26,6 +26,7 @@ module environment 'environment.bicep' = {
   name: 'container-app-environment'
   params: {
     environmentName: environmentName
+    location: location
   }
 }
 
@@ -33,7 +34,8 @@ module environment 'environment.bicep' = {
 module cosmosdb 'cosmosdb.bicep' = {
   name: 'cosmosdb'
   params: {
-    
+    location: location
+    primaryRegion: location
   }
 }
 
@@ -44,6 +46,7 @@ module apim 'api-management.bicep' = {
     apimName: apimName
     publisherName: 'Contoso Store'
     publisherEmail: 'demo@example.com'
+    apimLocation: location
   }
 }
 
@@ -51,6 +54,7 @@ module apim 'api-management.bicep' = {
 module pythonService 'container-http.bicep' = {
   name: pythonServiceAppName
   params: {
+    location: location
     containerAppName: pythonServiceAppName
     environmentId: environment.outputs.environmentId
     containerImage: pythonImage
@@ -103,6 +107,7 @@ module pythonService 'container-http.bicep' = {
 module goService 'container-http.bicep' = {
   name: goServiceAppName
   params: {
+    location: location
     containerAppName: goServiceAppName
     environmentId: environment.outputs.environmentId
     containerImage: goImage
@@ -120,6 +125,7 @@ module goService 'container-http.bicep' = {
 module nodeService 'container-http.bicep' = {
   name: nodeServiceAppName
   params: {
+    location: location
     containerAppName: nodeServiceAppName
     environmentId: environment.outputs.environmentId
     containerImage: nodeImage


### PR DESCRIPTION
## Purpose

After deploying this to a resource group that was not in canadacentral I saw the [main.bicep did not use the location parameter](https://github.com/Azure-Samples/container-apps-store-api-microservice/blob/main/deploy/main.bicep#L1) as an input to the nested deployments (modules).

This led to failed deployments when the resource group was in another region.

Hope it's ok I contribute a PR directly on this.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/matsest/container-apps-store-api-microservice/
cd container-apps-store-api-microservice
git checkout fix/location
```

Run the [deploy steps](https://github.com/Azure-Samples/container-apps-store-api-microservice#deploy-via-azure-bicep) while setting the location parameter in the deployment

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Resources get's deployed to the given location (only canadacentral and northeurope were available for me at the moment) regardless of resource group location, if the location parameter is set

## Other Information
<!-- Add any other helpful information that may be needed here. -->