### PR TITLE
Update README to include needing write permissions for pushing to ghcr

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ IMPORTANT: In general, each microservice should have an independent release and 
   | ---- | ----- |
   | AZURE_CREDENTIALS | The JSON credentials for an Azure subscription. [Learn more](https://docs.microsoft.com/azure/developer/github/connect-from-azure?tabs=azure-portal%2Cwindows#create-a-service-principal-and-add-it-as-a-github-secret) |
   | RESOURCE_GROUP | The name of the resource group to create |
-  | PACKAGES_TOKEN | A GitHub personal access token with the `read:packages` scope. [Learn more](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) |
+  | PACKAGES_TOKEN | A GitHub personal access token with the `write:packages` and `read:packages` scope. [Learn more](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) |
 
 3. Open the GitHub Actions, select the **Build and Deploy** action and choose to run the workflow.  
   


### PR DESCRIPTION
For the deploying via GitHub actions, I believe the build workflow first needs to push the images to the user's ghcr, which would require write:packages permissions. 

## Purpose
Update README to include needing write permissions for pushing to ghcr* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
