### PR TITLE
Change private registry to false so it works with GitHub/Container Apps Tutorial

### DIFF
--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -17,7 +17,7 @@ var goServiceAppName = 'go-app'
 
 param apimName string = 'store-api-mgmt-${uniqueString(resourceGroup().id)}'
 param deployApim bool = true
-param isPrivateRegistry bool = true
+param isPrivateRegistry bool = false
 
 param containerRegistry string
 param containerRegistryUsername string = 'testUser'


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Currently this repo will fail when deployed using the GitHub Actions tutorial at https://learn.microsoft.com/en-us/azure/container-apps/dapr-github-actions?tabs=bash. This fixes that issue by setting the GitHub registry to public in the bicep files.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

Updates a single line in `deploy/main.bicep`. Currently the GitHub tutorial at https://learn.microsoft.com/en-us/azure/container-apps/dapr-github-actions?tabs=bash uses this repo to demonstrate GitHub Actions and Azure Container Apps. However, the `deploy/main.bicep` marks the GitHub registry for the package as `true` but it looks like that should be `false`. 

This PR changes `isPrivateRegistry` to `false` in `deploy/main.bicep`.

<!-- Please check the one that applies to this PR using "x". -->
```
[ X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Run the tutorial at https://learn.microsoft.com/en-us/azure/container-apps/dapr-github-actions?tabs=bash but use this PR for the repo (or update `main.bicep` as mentioned above). The container app revision that is created should now be able to pull the image needed and load successfully in the browser.

## What to Check
* After going through the https://learn.microsoft.com/en-us/azure/container-apps/dapr-github-actions?tabs=bash tutorial you should be able to load the node-app UI successfully.